### PR TITLE
fix pip FileNotFoundError

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -6,12 +6,6 @@ import os
 import setuptools
 
 
-def read(*parts):
-    '''Read external file.'''
-    here = os.path.abspath(os.path.dirname(__file__))
-    return codecs.open(os.path.join(here, *parts), 'r').read()
-
-
 setuptools.setup(
     name='celery_mutex',
     version='0.1.0',
@@ -30,7 +24,6 @@ setuptools.setup(
     author='Lewis Franklin',
     author_email='lewis.franklin@gmail.com',
     description='Mutex for Celery tasks, which can be refined.',
-    long_description=read('README.md'),
     keywords='Celery tasks mutex',
     platforms='any',
     url='https://github.com/brolewis/celery_mutex',


### PR DESCRIPTION
Something has happened to pip over the years. The `setup.py` no longer works. After removing the `long_description`, I am able to install and the plugin still seems to work properly.

```
pip install --user celery_mutex
Collecting celery_mutex
  Using cached celery_mutex-0.1.0.tar.gz (3.5 kB)
    ERROR: Command errored out with exit status 1:
     command: /usr/bin/python3 -c 'import sys, setuptools, tokenize; sys.argv[0] = '"'"'/tmp/pip-install-yaepdwhu/celery-mutex/setup.py'"'"'; __file__='"'"'/tmp/pip-install-yaepdwhu/celery-mutex/setup.py'"'"';f=getattr(tokenize, '"'"'open'"'"', open)(__file__);code=f.read().replace('"'"'\r\n'"'"', '"'"'\n'"'"');f.close();exec(compile(code, __file__, '"'"'exec'"'"'))' egg_info --egg-base /tmp/pip-pip-egg-info-chyjwdww
         cwd: /tmp/pip-install-yaepdwhu/celery-mutex/
    Complete output (9 lines):
    Traceback (most recent call last):
      File "<string>", line 1, in <module>
      File "/tmp/pip-install-yaepdwhu/celery-mutex/setup.py", line 33, in <module>
        long_description=read('README.md'),
      File "/tmp/pip-install-yaepdwhu/celery-mutex/setup.py", line 12, in read
        return codecs.open(os.path.join(here, *parts), 'r').read()
      File "/usr/lib/python3.6/codecs.py", line 897, in open
        file = builtins.open(filename, mode, buffering)
    FileNotFoundError: [Errno 2] No such file or directory: '/tmp/pip-install-yaepdwhu/celery-mutex/README.md'
```